### PR TITLE
Fix/get creds from env

### DIFF
--- a/src/canal.app.src
+++ b/src/canal.app.src
@@ -1,6 +1,6 @@
 {application, canal,
  [{description, "An OTP application"},
-  {vsn, "0.2.2"},
+  {vsn, "0.2.3"},
   {registered, []},
   {mod, { canal_app, []}},
   {applications,

--- a/src/canal.erl
+++ b/src/canal.erl
@@ -388,7 +388,7 @@ req_type(RequestId, #state{requests = Requests}) ->
 -spec token(state()) -> {ok, binary()} | undefined.
 
 token(#state{auth = undefined}) ->
-    undefine;
+    undefined;
 
 token(#state{auth = #auth{token = undefined}}) ->
     undefined;

--- a/src/canal_utils.erl
+++ b/src/canal_utils.erl
@@ -27,12 +27,8 @@ error_msg(Format, Args) ->
 
 -spec getopt(atom()) -> term().
 
-getopt(auth_payload) ->
-    getopt2([
-        os:getenv("VAULT_AUTH_PAYLOAD"),
-        ?GET_ENV(auth_payload, false),
-        <<"">>
-    ]);
+getopt(credentials) ->
+    ?GET_ENV(credentials, undefined);
 
 getopt(timeout) ->
     getopt2([

--- a/test/canal_tests.erl
+++ b/test/canal_tests.erl
@@ -18,7 +18,9 @@ canal_test_() ->
 %% tests
 
 auth_subtest() ->
-    ok = canal:auth({approle, <<"bob_the_token">>, <<"bob_the_secret">>}).
+    Creds = {approle, <<"bob_the_token">>, <<"bob_the_secret">>},
+    ok = canal:auth(Creds),
+    Creds = ?GET_OPT(credentials).
 
 
 read_subtest() ->


### PR DESCRIPTION
This is to fix a bug where canal entered an unrecoverable bad state when the
canal gen_server was restarted. Envo was responsible for passing credentials to
canal. Canal did not store these credentials, so they did not persist across
restarts of the gen_server.