### PR TITLE
Suppress reauth with a provided token

### DIFF
--- a/src/canal.app.src
+++ b/src/canal.app.src
@@ -1,6 +1,6 @@
 {application, canal,
  [{description, "An OTP application"},
-  {vsn, "0.2.3"},
+  {vsn, "0.2.4"},
   {registered, []},
   {mod, { canal_app, []}},
   {applications,

--- a/src/canal.erl
+++ b/src/canal.erl
@@ -130,8 +130,9 @@ handle_call({write, Key, Body}, From, State) ->
 
 -spec handle_cast(_, state()) -> {noreply, state()}.
 
-handle_cast(reauth, State = #state{auth = #auth{token = Token}})
-    when Token =/= undefined ->
+% payload = undefined disambiguates a #auth{} from a passed-in token from canal
+% doing its own auth
+handle_cast(reauth, State = #state{auth = #auth{payload = undefined}}) ->
     {noreply, State};
 
 handle_cast(reauth, State = #state{auth = #auth{payload = Payload}}) ->


### PR DESCRIPTION
I made a mistake. I thought that `#auth.token = undefined` when canal uses a Vault token passed in through an environment variable, but it's actually `#auth.payload = undefined`. The `handle_cast` clause should now work properly in preventing canal from issuing a login request when using a token it did not itself request.