### PR TITLE
Remove buoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 canal
 =====
 
-[HashiCorp Vault](https://www.vaultproject.io/) client written in Erlang using [buoy](https://github.com/lpgauth/buoy)
+[HashiCorp Vault](https://www.vaultproject.io/) client written in Erlang
 
 [![Build Status](https://travis-ci.org/rkallos/canal.svg?branch=dev)](https://travis-ci.org/rkallos/canal.svg?branch=dev)
 [![Coverage Status](https://coveralls.io/repos/github/rkallos/canal/badge.svg?branch=dev)](https://coveralls.io/github/rkallos/canal?branch=dev)

--- a/rebar.config
+++ b/rebar.config
@@ -4,8 +4,6 @@
 {coveralls_service_name, "travis-ci"}.
 
 {deps, [
-  {buoy, "0.2.0",
-    {git, "https://github.com/lpgauth/buoy.git", {tag, "0.2.0"}}},
   {jiffy, "0.15.2",
     {git, "https://github.com/davisp/jiffy.git", {tag, "0.15.2"}}}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,24 +1,4 @@
-{"1.1.0",
-[{<<"buoy">>,
-  {git,"https://github.com/lpgauth/buoy.git",
-       {ref,"720290a7799d5c8a6d926ef2543f9112bbe80787"}},
-  0},
- {<<"foil">>,
-  {git,"https://github.com/lpgauth/foil.git",
-       {ref,"b55c30ff8b21daf89a85d1565d4b836c7f9e549b"}},
-  1},
- {<<"granderl">>,{pkg,<<"granderl">>,<<"0.1.5">>},2},
- {<<"jiffy">>,
+[{<<"jiffy">>,
   {git,"https://github.com/davisp/jiffy.git",
        {ref,"c942525130ff0271bd318715406f234c0dc9bc5a"}},
-  0},
- {<<"metal">>,{pkg,<<"metal">>,<<"0.1.1">>},2},
- {<<"shackle">>,
-  {git,"https://github.com/lpgauth/shackle.git",
-       {ref,"9106af7a01883f0160d3235662fa6c712f4ce326"}},
-  1}]}.
-[
-{pkg_hash,[
- {<<"granderl">>, <<"F20077A68BD80B8D8783BD15A052813C6483771DEC1A5B837D307CBE92F14122">>},
- {<<"metal">>, <<"5D3D1322DA7BCD34B94FED5486F577973685298883954F7A3E517EF5EF6953F5">>}]}
-].
+  0}].

--- a/src/canal.app.src
+++ b/src/canal.app.src
@@ -6,8 +6,9 @@
   {applications,
    [kernel,
     stdlib,
-    buoy,
-    jiffy
+    inets,
+    jiffy,
+    ssl
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
This PR replaces buoy with httpc from the Erlang standard library.

In our current production environment, connections to Vault are closed after 1 minute. This would occasionally leave canal in a state where it would not be able to issue requests to Vault until the connection is reestablished. With httpc, new connections are opened with each request, and to my knowledge, don't last beyond the lifetime of the request. I expect this will fix the problem.