### PR TITLE
Adds kubernetes auth method support

### DIFF
--- a/include/canal_internal.hrl
+++ b/include/canal_internal.hrl
@@ -14,4 +14,4 @@
 
 -type req_id()  :: httpc:request_id().
 -type req() :: {{pid(), reference()}, write | read, binary()}.
--type auth_method() :: {approle | ldap, binary(), binary()}.
+-type auth_method() :: {approle | ldap | kubernetes, binary(), binary()}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,10 @@
 {coveralls_coverdata, "_build/test/cover/eunit.coverdata"}.
 {coveralls_service_name, "travis-ci"}.
 
+{minimum_otp_vsn, "23"}.
+
 {deps, [
-  {jiffy, "0.15.2"}
+  {jiffy, "1.0.5"}
 ]}.
 
 {erl_opts, [debug_info]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
-{"1.1.0",
-[{<<"jiffy">>,{pkg,<<"jiffy">>,<<"0.15.2">>},0}]}.
+{"1.2.0",
+[{<<"jiffy">>,{pkg,<<"jiffy">>,<<"1.0.5">>},0}]}.
 [
 {pkg_hash,[
- {<<"jiffy">>, <<"DE266C390111FD4EA28B9302F0BC3D7472468F3B8E0ACEABFBEFA26D08CD73B7">>}]}
+ {<<"jiffy">>, <<"A69B58FAF7123534C20E1B0B7AE97AC52079CA02ED4B6989B4B380179CD63A54">>}]},
+{pkg_hash_ext,[
+ {<<"jiffy">>, <<"B617A53F46AE84F20D0C38951367DC947A2CF8CFF922AA5C6AC6B64B8B052289">>}]}
 ].

--- a/test/canal_test.hrl
+++ b/test/canal_test.hrl
@@ -1,1 +1,7 @@
 -define(TABLE, canal_table).
+
+-define(FIXTURE_APPROLE_ROLE, <<"bob_the_token">>).
+-define(FIXTURE_APPROLE_SECRET, <<"bob_the_secret">>).
+
+-define(FIXTURE_KUBERNETES_ROLE, <<"bob_the_role">>).
+-define(FIXTURE_KUBERNETES_JWT, <<"bob_the_service_token">>).

--- a/test/canal_tests.erl
+++ b/test/canal_tests.erl
@@ -10,7 +10,8 @@ canal_test_() ->
         fun () -> setup() end,
         fun (_) -> cleanup() end,
     [
-        fun auth_subtest/0,
+        fun auth_approle_subtest/0,
+        fun auth_kubernetes_subtest/0,
         fun read_subtest/0,
         fun write_subtest/0,
         fun cache_subtest/0
@@ -18,24 +19,30 @@ canal_test_() ->
 
 %% tests
 
-auth_subtest() ->
-    Creds = {approle, <<"bob_the_token">>, <<"bob_the_secret">>},
+auth_approle_subtest() ->
+    Creds = {approle, ?FIXTURE_APPROLE_ROLE, ?FIXTURE_APPROLE_SECRET},
+    ok = canal:auth(Creds),
+    Creds = ?GET_OPT(credentials).
+
+
+auth_kubernetes_subtest() ->
+    Creds = {kubernetes, ?FIXTURE_KUBERNETES_ROLE, ?FIXTURE_KUBERNETES_JWT},
     ok = canal:auth(Creds),
     Creds = ?GET_OPT(credentials).
 
 
 read_subtest() ->
-    ok = canal:auth({approle, <<"bob_the_token">>, <<"bob_the_secret">>}),
+    ok = canal:auth({approle, ?FIXTURE_APPROLE_ROLE, ?FIXTURE_APPROLE_SECRET}),
     {error, {404, []}} = canal:read(<<"foo">>).
 
 
 write_subtest() ->
-    ok = canal:auth({approle, <<"bob_the_token">>, <<"bob_the_secret">>}),
+    ok = canal:auth({approle, ?FIXTURE_APPROLE_ROLE, ?FIXTURE_APPROLE_SECRET}),
     ok = canal:write(<<"foo">>, <<"bar">>),
     {ok, #{<<"value">> := <<"bar">>}} = canal:read(<<"foo">>).
 
 cache_subtest() ->
-    ok = canal:auth({approle, <<"bob_the_token">>, <<"bob_the_secret">>}),
+    ok = canal:auth({approle, ?FIXTURE_APPROLE_ROLE, ?FIXTURE_APPROLE_SECRET}),
     ok = canal:write(<<"foo">>, <<"bar">>),
     {ok, #{<<"value">> := <<"bar">>}} = canal:read(<<"foo">>),
     canal_http_server:stop(),


### PR DESCRIPTION
Bumps jiffy to 1.0.5 and minimum otp version required to 23. Refactors auth test fixtures.